### PR TITLE
Refactor link handler patch to use wrap and return _old result

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -88,7 +88,7 @@ def saveField(note, fld, val):
     note.flush()
 
 
-def myLinkHandler(reviewer, url):
+def myLinkHandler(reviewer, url, _old):
     if url.startswith("ankisave#"):
         fld, val = url.replace("ankisave#", "").split("#", 1)
         note = reviewer.card.note()
@@ -122,8 +122,7 @@ def myLinkHandler(reviewer, url):
         elif reviewer.state == "answer":
             reviewer._showAnswer()
     else:
-        origLinkHandler(reviewer, url)
+        return _old(reviewer, url)
 
 
-origLinkHandler = Reviewer._linkHandler
-Reviewer._linkHandler = myLinkHandler
+Reviewer._linkHandler = wrap(Reviewer._linkHandler, myLinkHandler, "around")


### PR DESCRIPTION
Fixes compatibility with other add-ons that also utilize the link handler (the key change here being the return statement that preserves existing Python → JS bridges).

Using anki.hooks.wrap to perform monkey-patches is not an absolute necessity, but since it's the canonical way to do these things in Anki add-ons, I thought it would be good to also refactor that.